### PR TITLE
Fix miri errors and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ concurrent_map_minimum = ["concurrent-map"]
 debug = true
 
 [dependencies]
-concurrent-map = { version = "5.0", features = ["serde"], path = "../concurrent-map", optional = true }
+concurrent-map = { version = "5.0", features = ["serde"], optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Only took me 8 months to get around to it, took a stab at it multiple times but I think this is an actual useful work. This PR includes:
1. All tests compile and pass with all feature combination including miri (verified with `cargo hack`).
2. Only leaves a couple warnings I can't figure out it yet, both are related to pointer provenance in `Deref`.

I can't say I fully understand the provenance APIs, but I got enough to somewhat explain to miri that it should just trust me here.
